### PR TITLE
Package Utility as macOS Application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
 .DS_Store
 vanta_vulnerabilities.db
 .venv/
+venv/
 __pycache__/
 *.pyc
 *.pyo
 *.egg-info/
 dist/
 build/
+*.dmg
+dmg_temp/
+*.app

--- a/MACOS_APP_BUILD.md
+++ b/MACOS_APP_BUILD.md
@@ -1,0 +1,262 @@
+# Building the macOS App Bundle
+
+This guide explains how to package the Vanta Vulnerability Statistics utility as a macOS app bundle.
+
+## Prerequisites
+
+- **macOS** system (for final build)
+- **Python 3.8+** installed
+- **Xcode Command Line Tools** (install via: `xcode-select --install`)
+
+## Quick Start
+
+The easiest way to build the app is using the provided build script:
+
+```bash
+./build_macos_app.sh
+```
+
+This will:
+1. Create a Python virtual environment
+2. Install all dependencies including py2app
+3. Build the macOS app bundle
+4. Output the app to `dist/vanta_vuln_gui.app`
+
+## Step-by-Step Manual Build
+
+If you prefer to build manually or need to customize the process:
+
+### 1. Install Dependencies
+
+```bash
+# Create and activate virtual environment
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+```
+
+### 2. (Optional) Create App Icon
+
+If you want a custom icon for your app:
+
+1. Create a 1024x1024 PNG icon
+2. Convert it to .icns format (see `create_icon.md` for detailed instructions)
+3. Save as `app_icon.icns` in the project root
+
+The build will automatically include the icon if `app_icon.icns` exists.
+
+### 3. Build the App
+
+```bash
+# Clean previous builds
+rm -rf build dist
+
+# Build the app
+python3 setup.py py2app
+```
+
+### 4. Test the App
+
+```bash
+# Run the app
+open dist/vanta_vuln_gui.app
+```
+
+## Installing the App
+
+### For Personal Use
+
+Copy the app to your Applications folder:
+
+```bash
+cp -r dist/vanta_vuln_gui.app /Applications/
+```
+
+### For Distribution
+
+Create a DMG installer:
+
+```bash
+./create_dmg.sh
+```
+
+This creates `VantaVulnStats-1.0.0.dmg` that users can:
+1. Download and open
+2. Drag the app to their Applications folder
+
+## Configuration
+
+### App Bundle Settings
+
+The app bundle configuration is defined in `setup.py`. Key settings:
+
+- **Bundle Name**: Vanta Vuln Stats
+- **Bundle ID**: com.vanta.vuln-stats
+- **Version**: 1.0.0
+- **Minimum macOS**: 10.13 (High Sierra)
+
+### Customization
+
+To customize the app, edit `setup.py`:
+
+```python
+'plist': {
+    'CFBundleName': 'Your App Name',
+    'CFBundleDisplayName': 'Your Display Name',
+    'CFBundleIdentifier': 'com.yourcompany.yourapp',
+    'CFBundleVersion': '1.0.0',
+    # ... other settings
+}
+```
+
+## Included Files
+
+The app bundle includes:
+
+- `vanta_vuln_gui.py` - Main GUI application
+- `vanta_vuln_stats.py` - Core statistics module
+- `VANTA_API_CREDENTIALS.env` - Credentials template
+- `README.md` - Documentation
+- `requirements.txt` - Python dependencies
+
+## Troubleshooting
+
+### Build Fails with "No module named 'PySide6'"
+
+Make sure you've installed dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+### App Won't Open: "App is damaged"
+
+This happens on macOS Catalina+ when the app isn't signed. To bypass for testing:
+```bash
+xattr -cr dist/vanta_vuln_gui.app
+```
+
+For distribution, you'll need to sign the app with an Apple Developer certificate.
+
+### Missing Icon
+
+If you see a generic Python icon:
+- The `app_icon.icns` file wasn't found during build
+- Follow instructions in `create_icon.md` to create one
+- Rebuild the app
+
+### Import Errors at Runtime
+
+If the app crashes with import errors:
+1. Check that all required packages are listed in `setup.py` under `'packages'` or `'includes'`
+2. Verify the package is installed in your virtual environment
+3. Rebuild the app
+
+### App Bundle Size is Large
+
+The app includes Python and all dependencies (~100-200 MB). To reduce size:
+1. Remove unused packages from `requirements.txt`
+2. Add more packages to `'excludes'` in `setup.py`
+3. Use `'semi_standalone': True` for smaller size (requires Python on target system)
+
+## Code Signing (Optional)
+
+For distribution outside of personal use, sign your app:
+
+### 1. Get Developer Certificate
+
+Sign up for the [Apple Developer Program](https://developer.apple.com/programs/) ($99/year).
+
+### 2. Sign the App
+
+```bash
+codesign --deep --force --verify --verbose \
+    --sign "Developer ID Application: Your Name (TEAM_ID)" \
+    dist/vanta_vuln_gui.app
+```
+
+### 3. Notarize (macOS 10.15+)
+
+```bash
+# Create a zip for notarization
+ditto -c -k --keepParent dist/vanta_vuln_gui.app vanta_vuln_gui.zip
+
+# Submit for notarization
+xcrun notarytool submit vanta_vuln_gui.zip \
+    --apple-id "your@email.com" \
+    --team-id "TEAM_ID" \
+    --wait
+
+# Staple the notarization ticket
+xcrun stapler staple dist/vanta_vuln_gui.app
+```
+
+## Building on Non-macOS Systems
+
+You can prepare the build on Linux/Windows, but the final build must be done on macOS:
+
+1. Run the build script on your current system (it will warn but continue)
+2. Copy the entire project to a macOS system
+3. Run `./build_macos_app.sh` on macOS
+
+## Directory Structure
+
+After building, you'll have:
+
+```
+vanta-vuln-stats/
+├── build/                      # Temporary build files (can be deleted)
+├── dist/
+│   └── vanta_vuln_gui.app     # Your macOS app bundle
+├── venv/                       # Virtual environment (for building)
+├── setup.py                    # py2app configuration
+├── build_macos_app.sh          # Build script
+├── create_dmg.sh               # DMG creation script
+└── ... (source files)
+```
+
+## Next Steps
+
+After building:
+
+1. **Test thoroughly**: Open the app and test all functionality
+2. **Check credentials**: Ensure `VANTA_API_CREDENTIALS.env` is properly configured
+3. **Test on clean macOS**: Verify the app works on a Mac without Python installed
+4. **Create DMG**: Use `create_dmg.sh` for easy distribution
+5. **Sign & notarize**: Required for distribution outside personal use
+
+## Advanced Configuration
+
+### Multiple Apps
+
+To build both GUI and CLI as separate apps, modify `setup.py`:
+
+```python
+APP = ['vanta_vuln_gui.py']  # GUI app
+# Also could add CLI wrapper if needed
+```
+
+### Custom Launch Options
+
+Create a wrapper script that sets environment variables or custom paths before launching the Python app.
+
+### Database Location
+
+By default, the app looks for the database in the same directory as the app. To change this, modify the default path in `vanta_vuln_gui.py`.
+
+## Resources
+
+- [py2app Documentation](https://py2app.readthedocs.io/)
+- [Apple App Distribution Guide](https://developer.apple.com/documentation/xcode/distributing-your-app-for-beta-testing-and-releases)
+- [macOS Code Signing Guide](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution)
+
+## Getting Help
+
+If you encounter issues:
+
+1. Check the error messages in the build output
+2. Review `setup.py` configuration
+3. Verify all dependencies are installed
+4. Check Python version compatibility (3.8+)
+5. Try rebuilding in a fresh virtual environment

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A comprehensive Python utility for fetching and analyzing vulnerability data fro
 
 ## Installation
 
+### Standard Installation (CLI & GUI)
+
 1. Install dependencies:
 ```bash
 pip install -r requirements.txt
@@ -55,6 +57,26 @@ uv pip install -r requirements.txt
   "client_secret": "your_client_secret"
 }
 ```
+
+### macOS App Bundle
+
+For macOS users, you can build a standalone app bundle that doesn't require Python installation:
+
+```bash
+./build_macos_app.sh
+```
+
+This creates a native macOS application at `dist/vanta_vuln_gui.app` that you can:
+- Double-click to run
+- Copy to your Applications folder
+- Distribute to other macOS users (via DMG)
+
+**For detailed instructions**, see [MACOS_APP_BUILD.md](MACOS_APP_BUILD.md) which covers:
+- Building the app bundle
+- Creating a custom icon
+- Creating DMG installers
+- Code signing and notarization
+- Troubleshooting
 
 ## Usage
 

--- a/build_macos_app.sh
+++ b/build_macos_app.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Build script for creating macOS app bundle
+# Usage: ./build_macos_app.sh
+#
+
+set -e  # Exit on error
+
+echo "================================================"
+echo "Vanta Vulnerability Stats - macOS App Builder"
+echo "================================================"
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "Warning: This script is designed for macOS."
+    echo "You can still run it to prepare the build, but the final .app bundle"
+    echo "will need to be built on a macOS system."
+    echo ""
+fi
+
+# Check Python version
+echo "Checking Python version..."
+PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+echo "Found Python $PYTHON_VERSION"
+echo ""
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+    echo "Creating virtual environment..."
+    python3 -m venv venv
+    echo "Virtual environment created."
+else
+    echo "Virtual environment already exists."
+fi
+echo ""
+
+# Activate virtual environment
+echo "Activating virtual environment..."
+source venv/bin/activate
+echo ""
+
+# Install dependencies
+echo "Installing dependencies..."
+pip install --upgrade pip
+pip install -r requirements.txt
+pip install py2app
+echo ""
+
+# Clean previous builds
+echo "Cleaning previous builds..."
+rm -rf build dist
+echo "Clean complete."
+echo ""
+
+# Build the app
+echo "Building macOS app bundle..."
+python3 setup.py py2app
+echo ""
+
+# Check if build was successful
+if [ -d "dist/vanta_vuln_gui.app" ]; then
+    echo "================================================"
+    echo "SUCCESS! App bundle created at:"
+    echo "  dist/vanta_vuln_gui.app"
+    echo ""
+    echo "You can now:"
+    echo "  1. Open the app: open dist/vanta_vuln_gui.app"
+    echo "  2. Copy to Applications: cp -r dist/vanta_vuln_gui.app /Applications/"
+    echo "  3. Create DMG for distribution (see create_dmg.sh)"
+    echo "================================================"
+else
+    echo "================================================"
+    echo "ERROR: Build failed. Check the output above for errors."
+    echo "================================================"
+    exit 1
+fi

--- a/create_dmg.sh
+++ b/create_dmg.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Create a DMG installer for the macOS app
+# Usage: ./create_dmg.sh
+#
+# Note: This script requires the app to be built first (run build_macos_app.sh)
+#       and should be run on macOS
+#
+
+set -e  # Exit on error
+
+APP_NAME="Vanta Vuln Stats"
+APP_BUNDLE="dist/vanta_vuln_gui.app"
+DMG_NAME="VantaVulnStats-1.0.0.dmg"
+VOLUME_NAME="Vanta Vuln Stats Installer"
+DMG_TEMP="dmg_temp"
+
+echo "================================================"
+echo "Creating DMG Installer"
+echo "================================================"
+echo ""
+
+# Check if running on macOS
+if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "ERROR: This script must be run on macOS."
+    exit 1
+fi
+
+# Check if app bundle exists
+if [ ! -d "$APP_BUNDLE" ]; then
+    echo "ERROR: App bundle not found at $APP_BUNDLE"
+    echo "Please run build_macos_app.sh first."
+    exit 1
+fi
+
+# Clean up any previous DMG
+echo "Cleaning up previous DMG..."
+rm -f "$DMG_NAME"
+rm -rf "$DMG_TEMP"
+echo ""
+
+# Create temporary directory
+echo "Creating temporary directory..."
+mkdir -p "$DMG_TEMP"
+echo ""
+
+# Copy app bundle to temp directory
+echo "Copying app bundle..."
+cp -r "$APP_BUNDLE" "$DMG_TEMP/"
+echo ""
+
+# Create symbolic link to Applications folder
+echo "Creating Applications symlink..."
+ln -s /Applications "$DMG_TEMP/Applications"
+echo ""
+
+# Create DMG
+echo "Creating DMG..."
+hdiutil create -volname "$VOLUME_NAME" \
+    -srcfolder "$DMG_TEMP" \
+    -ov -format UDZO \
+    "$DMG_NAME"
+echo ""
+
+# Clean up
+echo "Cleaning up..."
+rm -rf "$DMG_TEMP"
+echo ""
+
+echo "================================================"
+echo "SUCCESS! DMG created at:"
+echo "  $DMG_NAME"
+echo ""
+echo "You can now distribute this DMG file."
+echo "Users can drag the app to their Applications folder."
+echo "================================================"

--- a/create_icon.md
+++ b/create_icon.md
@@ -1,0 +1,43 @@
+# Creating an App Icon
+
+To create a custom icon for the macOS app, follow these steps:
+
+## Option 1: Using iconutil (macOS only)
+
+1. Create a folder structure with different icon sizes:
+   ```
+   VantaVulnStats.iconset/
+   ├── icon_16x16.png
+   ├── icon_16x16@2x.png
+   ├── icon_32x32.png
+   ├── icon_32x32@2x.png
+   ├── icon_128x128.png
+   ├── icon_128x128@2x.png
+   ├── icon_256x256.png
+   ├── icon_256x256@2x.png
+   ├── icon_512x512.png
+   └── icon_512x512@2x.png
+   ```
+
+2. Convert to .icns:
+   ```bash
+   iconutil -c icns VantaVulnStats.iconset -o app_icon.icns
+   ```
+
+## Option 2: Using Online Tools
+
+1. Create or find a 1024x1024 PNG icon
+2. Use an online converter like:
+   - https://cloudconvert.com/png-to-icns
+   - https://iconverticons.com/online/
+
+3. Save the result as `app_icon.icns` in the project root
+
+## Option 3: Use Default Icon
+
+If you don't create a custom icon, comment out the `'iconfile'` line in `setup.py`:
+```python
+# 'iconfile': 'app_icon.icns',  # Optional: add your icon file
+```
+
+The app will use the default Python application icon.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31.0
 PySide6>=6.7.0
+py2app>=0.28.0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Setup script for building macOS app bundle using py2app.
+"""
+
+import os
+from setuptools import setup
+
+APP = ['vanta_vuln_gui.py']
+DATA_FILES = [
+    ('', ['VANTA_API_CREDENTIALS.env', 'README.md', 'requirements.txt']),
+]
+
+# Build OPTIONS dictionary
+OPTIONS = {
+    'argv_emulation': False,  # Disable for PySide6
+    'plist': {
+        'CFBundleName': 'Vanta Vuln Stats',
+        'CFBundleDisplayName': 'Vanta Vulnerability Statistics',
+        'CFBundleIdentifier': 'com.vanta.vuln-stats',
+        'CFBundleVersion': '1.0.0',
+        'CFBundleShortVersionString': '1.0.0',
+        'CFBundleInfoDictionaryVersion': '6.0',
+        'NSHighResolutionCapable': True,
+        'NSRequiresAquaSystemAppearance': False,
+        'LSMinimumSystemVersion': '10.13.0',
+        'CFBundleDocumentTypes': [
+            {
+                'CFBundleTypeName': 'SQLite Database',
+                'CFBundleTypeRole': 'Viewer',
+                'LSItemContentTypes': ['public.database'],
+                'LSHandlerRank': 'Alternate',
+            }
+        ],
+    },
+    'packages': ['PySide6', 'requests', 'sqlite3', 'certifi'],
+    'includes': ['vanta_vuln_stats'],
+    'excludes': ['tkinter', 'matplotlib', 'numpy', 'pandas'],
+    'semi_standalone': False,
+    'site_packages': True,
+}
+
+# Add icon if it exists
+if os.path.exists('app_icon.icns'):
+    OPTIONS['iconfile'] = 'app_icon.icns'
+
+setup(
+    name='VantaVulnStats',
+    app=APP,
+    data_files=DATA_FILES,
+    options={'py2app': OPTIONS},
+    setup_requires=['py2app'],
+    install_requires=[
+        'requests>=2.31.0',
+        'PySide6>=6.7.0',
+    ],
+)


### PR DESCRIPTION
- Add py2app setup.py configuration with proper Info.plist settings
- Create build_macos_app.sh script for automated app building
- Create create_dmg.sh script for DMG installer creation
- Add comprehensive MACOS_APP_BUILD.md documentation
- Add create_icon.md with icon creation instructions
- Update requirements.txt to include py2app
- Update README.md with macOS app bundle section
- Update .gitignore to exclude build artifacts (venv, dmg, etc.)

The app bundle can be built by running ./build_macos_app.sh and will create a standalone macOS application that doesn't require Python installation on the target system.