### PR TITLE
Add dashboard analytics and detail pane to GUI

### DIFF
--- a/gui/__init__.py
+++ b/gui/__init__.py
@@ -8,6 +8,8 @@ secure credential management, settings persistence, data models, workers, and UI
 from gui.credentials_dialog import CredentialsDialog
 from gui.credentials_manager import CredentialsManager
 from gui.database_manager import DatabaseCache, DatabaseConnectionPool, DatabaseManager
+from gui.dashboard import DashboardWidget
+from gui.detail_panel import VulnerabilityDetailPanel
 from gui.models import VulnerabilitySortFilterProxyModel, VulnerabilityTableModel
 from gui.settings_manager import SettingsManager
 from gui.workers import (
@@ -30,4 +32,6 @@ __all__ = [
     "DatabaseManager",
     "DatabaseConnectionPool",
     "DatabaseCache",
+    "DashboardWidget",
+    "VulnerabilityDetailPanel",
 ]

--- a/gui/dashboard.py
+++ b/gui/dashboard.py
@@ -1,0 +1,272 @@
+"""Dashboard widgets displaying vulnerability summary visuals."""
+
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime
+from typing import Dict, Iterable, Optional
+
+from PySide6 import QtCore, QtWidgets
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+
+
+class DashboardWidget(QtWidgets.QWidget):
+    """Composite widget that renders KPI cards and charts."""
+
+    SEVERITY_ORDER = ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+
+        self._kpi_labels: Dict[str, QtWidgets.QLabel] = {}
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(12)
+
+        layout.addLayout(self._build_kpi_row())
+        layout.addLayout(self._build_charts())
+
+
+    def _build_kpi_row(self) -> QtWidgets.QLayout:
+        row_layout = QtWidgets.QHBoxLayout()
+        row_layout.setSpacing(12)
+
+        kpi_definitions = [
+            ("total", "Total Vulnerabilities"),
+            ("active", "Active"),
+            ("fixable", "Fixable"),
+            ("avg_cvss", "Avg. CVSS"),
+        ]
+
+        for key, label in kpi_definitions:
+            frame = QtWidgets.QFrame()
+            frame.setObjectName(f"kpi_{key}")
+            frame.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+            frame.setStyleSheet(
+                "QFrame {"
+                "  border-radius: 8px;"
+                "  border: 1px solid palette(midlight);"
+                "  background: palette(base);"
+                "}"
+            )
+
+            frame_layout = QtWidgets.QVBoxLayout(frame)
+            frame_layout.setContentsMargins(12, 8, 12, 8)
+
+            title = QtWidgets.QLabel(label)
+            title.setObjectName(f"kpi_title_{key}")
+            title.setStyleSheet("font-size: 11pt; color: palette(mid);")
+
+            value_label = QtWidgets.QLabel("0")
+            value_label.setObjectName(f"kpi_value_{key}")
+            value_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            value_label.setStyleSheet("font-size: 20pt; font-weight: 600;")
+
+            frame_layout.addWidget(title)
+            frame_layout.addWidget(value_label)
+            frame_layout.addStretch()
+
+            self._kpi_labels[key] = value_label
+            row_layout.addWidget(frame)
+
+        row_layout.addStretch()
+        return row_layout
+
+    def _build_charts(self) -> QtWidgets.QLayout:
+        grid = QtWidgets.QGridLayout()
+        grid.setSpacing(12)
+
+        self._severity_canvas = FigureCanvas(Figure(figsize=(4, 3)))
+        self._severity_ax = self._severity_canvas.figure.add_subplot(111)
+        self._severity_canvas.figure.tight_layout()
+
+        self._integration_canvas = FigureCanvas(Figure(figsize=(4, 3)))
+        self._integration_ax = self._integration_canvas.figure.add_subplot(111)
+        self._integration_canvas.figure.tight_layout()
+
+        self._trend_canvas = FigureCanvas(Figure(figsize=(8, 3)))
+        self._trend_ax = self._trend_canvas.figure.add_subplot(111)
+        self._trend_canvas.figure.tight_layout()
+
+        self._severity_canvas.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding
+        )
+        self._integration_canvas.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding
+        )
+        self._trend_canvas.setSizePolicy(
+            QtWidgets.QSizePolicy.Policy.Expanding, QtWidgets.QSizePolicy.Policy.Expanding
+        )
+
+        grid.addWidget(self._severity_canvas, 0, 0)
+        grid.addWidget(self._integration_canvas, 0, 1)
+        grid.addWidget(self._trend_canvas, 1, 0, 1, 2)
+
+        return grid
+
+    # Public API ---------------------------------------------------------
+
+    def clear(self) -> None:
+        """Reset all dashboard visuals."""
+        for label in self._kpi_labels.values():
+            label.setText("0")
+
+        for axis in (self._severity_ax, self._integration_ax, self._trend_ax):
+            axis.clear()
+            axis.text(0.5, 0.5, "No data", ha="center", va="center")
+        self._severity_canvas.draw_idle()
+        self._integration_canvas.draw_idle()
+        self._trend_canvas.draw_idle()
+
+    def update_data(self, stats: Dict, vulnerabilities: Iterable[Dict]) -> None:
+        """Update the dashboard with new statistics."""
+        if not stats:
+            self.clear()
+            return
+
+        self._update_kpis(stats, vulnerabilities)
+        self._update_severity_chart(stats.get("by_severity", {}))
+        self._update_integration_chart(stats.get("by_integration", {}))
+        self._update_trend_chart(vulnerabilities)
+
+    # Internal helpers ---------------------------------------------------
+
+    def _update_kpis(self, stats: Dict, vulnerabilities: Iterable[Dict]) -> None:
+        total = stats.get("total_count", 0)
+        active = stats.get("active", 0)
+        fixable = stats.get("fixable", 0)
+
+        self._kpi_labels["total"].setText(str(total))
+        self._kpi_labels["active"].setText(str(active))
+        self._kpi_labels["fixable"].setText(str(fixable))
+
+        cvss_scores = [
+            vuln.get("cvssSeverityScore")
+            for vuln in vulnerabilities
+            if vuln.get("cvssSeverityScore") is not None
+        ]
+        if cvss_scores:
+            avg_cvss = sum(cvss_scores) / len(cvss_scores)
+            self._kpi_labels["avg_cvss"].setText(f"{avg_cvss:.1f}")
+        else:
+            self._kpi_labels["avg_cvss"].setText("–")
+
+    def _update_severity_chart(self, severity_counts: Dict[str, int]) -> None:
+        self._severity_ax.clear()
+        values = []
+        labels = []
+        colors = []
+
+        severity_palette = {
+            "CRITICAL": "#dc3545",
+            "HIGH": "#ffc107",
+            "MEDIUM": "#ff9800",
+            "LOW": "#4caf50",
+        }
+
+        for severity in self.SEVERITY_ORDER:
+            count = severity_counts.get(severity, 0)
+            if count:
+                labels.append(severity.title())
+                values.append(count)
+                colors.append(severity_palette.get(severity, "#6c757d"))
+
+        if values:
+            wedges, texts, autotexts = self._severity_ax.pie(
+                values,
+                labels=labels,
+                colors=colors,
+                autopct="%1.0f%%",
+                startangle=140,
+                textprops={"color": "white", "weight": "bold"},
+            )
+            for text in texts:
+                text.set_color("black")
+            self._severity_ax.set_title("By Severity")
+        else:
+            self._severity_ax.text(0.5, 0.5, "No severity data", ha="center", va="center")
+        self._severity_canvas.draw_idle()
+
+    def _update_integration_chart(self, integration_counts: Dict[str, int]) -> None:
+        self._integration_ax.clear()
+
+        if not integration_counts:
+            self._integration_ax.text(0.5, 0.5, "No integration data", ha="center", va="center")
+            self._integration_canvas.draw_idle()
+            return
+
+        items = sorted(integration_counts.items(), key=lambda item: item[1], reverse=True)
+        labels = [label or "Unknown" for label, _ in items]
+        values = [value for _, value in items]
+
+        bars = self._integration_ax.bar(labels, values, color="#007bff")
+        self._integration_ax.set_title("By Integration Source")
+        self._integration_ax.set_ylabel("Count")
+        self._integration_ax.tick_params(axis="x", rotation=30, labelsize=8)
+        self._integration_ax.set_ylim(0, max(values) * 1.2 if values else 1)
+
+        for bar, value in zip(bars, values):
+            self._integration_ax.text(
+                bar.get_x() + bar.get_width() / 2,
+                bar.get_height() + 0.1,
+                str(value),
+                ha="center",
+                va="bottom",
+                fontsize=8,
+            )
+
+        self._integration_canvas.draw_idle()
+
+    def _update_trend_chart(self, vulnerabilities: Iterable[Dict]) -> None:
+        self._trend_ax.clear()
+
+        new_counter: Counter[str] = Counter()
+        remediated_counter: Counter[str] = Counter()
+
+        for vuln in vulnerabilities:
+            first_detected = vuln.get("firstDetectedDate")
+            if first_detected:
+                month = self._month_bucket(first_detected)
+                if month:
+                    new_counter[month] += 1
+
+            deactivated = (
+                vuln.get("deactivateMetadata", {}) or {}
+            ).get("deactivatedOnDate")
+            if deactivated:
+                month = self._month_bucket(deactivated)
+                if month:
+                    remediated_counter[month] += 1
+
+        all_months = sorted(set(new_counter) | set(remediated_counter))
+
+        if not all_months:
+            self._trend_ax.text(0.5, 0.5, "No trend data", ha="center", va="center")
+            self._trend_canvas.draw_idle()
+            return
+
+        new_values = [new_counter.get(month, 0) for month in all_months]
+        rem_values = [remediated_counter.get(month, 0) for month in all_months]
+
+        self._trend_ax.plot(all_months, new_values, marker="o", label="New")
+        self._trend_ax.plot(all_months, rem_values, marker="o", label="Remediated")
+        self._trend_ax.fill_between(all_months, new_values, alpha=0.1)
+        self._trend_ax.fill_between(all_months, rem_values, alpha=0.1)
+        self._trend_ax.set_title("Trend Over Time")
+        self._trend_ax.set_ylabel("Count")
+        self._trend_ax.set_xlabel("Month")
+        self._trend_ax.legend()
+        self._trend_ax.set_ylim(bottom=0)
+        self._trend_ax.tick_params(axis="x", rotation=30, labelsize=8)
+
+        self._trend_canvas.draw_idle()
+
+    @staticmethod
+    def _month_bucket(date_str: str) -> Optional[str]:
+        try:
+            dt = datetime.fromisoformat(date_str.replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+        return dt.strftime("%Y-%m")

--- a/gui/detail_panel.py
+++ b/gui/detail_panel.py
@@ -1,0 +1,139 @@
+"""Detail panel for displaying vulnerability metadata."""
+
+from __future__ import annotations
+
+import html
+from datetime import datetime
+from typing import Dict, Optional
+
+from PySide6 import QtWidgets
+
+
+class VulnerabilityDetailPanel(QtWidgets.QTextBrowser):
+    """Rich-text panel that renders vulnerability details."""
+
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self.setOpenExternalLinks(True)
+        self.setReadOnly(True)
+        self.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        self.setObjectName("vulnerabilityDetailPanel")
+        self.setStyleSheet("QTextBrowser { padding: 12px; }")
+        self._show_placeholder()
+
+    def display_vulnerability(self, vulnerability: Optional[Dict]) -> None:
+        """Render the given vulnerability in the panel."""
+        if not vulnerability:
+            self._show_placeholder()
+            return
+
+        severity = vulnerability.get("severity", "Unknown")
+        severity_badge = self._severity_badge(severity)
+        status = "Remediated" if vulnerability.get("deactivateMetadata") else "Active"
+        fixable = "Yes" if vulnerability.get("isFixable") else "No"
+
+        fields = {
+            "ID": vulnerability.get("id", "N/A"),
+            "Asset": vulnerability.get("targetId", "N/A"),
+            "Integration": vulnerability.get("integrationId", "Unknown"),
+            "Source": vulnerability.get("scanSource", "Unknown"),
+            "Status": status,
+            "Fixable": fixable,
+            "CVSS": self._format_score(vulnerability.get("cvssSeverityScore")),
+            "Scanner Score": self._format_score(vulnerability.get("scannerScore")),
+        }
+
+        dates = {
+            "Created": self._format_datetime(vulnerability.get("createdAt")),
+            "First Detected": self._format_datetime(vulnerability.get("firstDetectedDate")),
+            "Last Detected": self._format_datetime(vulnerability.get("lastDetectedDate")),
+            "Remediated": self._format_datetime(
+                (vulnerability.get("deactivateMetadata") or {}).get("deactivatedOnDate")
+            ),
+        }
+
+        related_vulns = vulnerability.get("relatedVulns")
+        related_section = ""
+        if related_vulns:
+            related_items = "".join(
+                f"<li>{html.escape(str(item))}</li>" for item in related_vulns
+            )
+            related_section = f"<h4>Related Vulnerabilities</h4><ul>{related_items}</ul>"
+
+        external_url = vulnerability.get("externalUrl")
+        link_section = ""
+        if external_url:
+            safe_url = html.escape(external_url)
+            link_section = f'<p><a href="{safe_url}">Open in Vanta ↗</a></p>'
+
+        description = vulnerability.get("description") or vulnerability.get("details")
+        description_html = (
+            f"<h4>Description</h4><p>{html.escape(description)}</p>"
+            if description
+            else ""
+        )
+
+        html_content = f"""
+            <h2>{html.escape(vulnerability.get('name', 'Unnamed Vulnerability'))}</h2>
+            <p>{severity_badge}</p>
+            <table cellspacing="0" cellpadding="4">
+                {''.join(f'<tr><th align="left">{html.escape(label)}</th><td>{html.escape(str(value))}</td></tr>' for label, value in fields.items())}
+            </table>
+            <h4>Key Dates</h4>
+            <table cellspacing="0" cellpadding="4">
+                {''.join(f'<tr><th align="left">{html.escape(label)}</th><td>{html.escape(value)}</td></tr>' for label, value in dates.items())}
+            </table>
+            {description_html}
+            {related_section}
+            {link_section}
+        """
+
+        self.setHtml(html_content)
+
+    def display_selection_summary(self, count: int) -> None:
+        """Show message when multiple vulnerabilities are selected."""
+        self.setHtml(
+            f"<h3>{count} vulnerabilities selected</h3>"
+            "<p>Use the context menu for bulk operations.</p>"
+        )
+
+    # Helpers -------------------------------------------------------------
+
+    def _show_placeholder(self) -> None:
+        self.setHtml(
+            "<h3>No vulnerability selected</h3>"
+            "<p>Select a vulnerability from the table to view its details.</p>"
+        )
+
+    @staticmethod
+    def _format_datetime(value: Optional[str]) -> str:
+        if not value:
+            return "—"
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return value
+        return dt.strftime("%Y-%m-%d %H:%M")
+
+    @staticmethod
+    def _format_score(value: Optional[float]) -> str:
+        if value is None:
+            return "—"
+        try:
+            return f"{float(value):.1f}"
+        except (TypeError, ValueError):
+            return str(value)
+
+    @staticmethod
+    def _severity_badge(severity: str) -> str:
+        colors = {
+            "CRITICAL": "#dc3545",
+            "HIGH": "#ffc107",
+            "MEDIUM": "#ff9800",
+            "LOW": "#4caf50",
+        }
+        color = colors.get(severity.upper(), "#6c757d")
+        return (
+            f'<span style="display:inline-block;padding:4px 8px;'
+            f'border-radius:12px;background:{color};color:#fff;font-weight:600;">{html.escape(severity.title())}</span>'
+        )

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ OPTIONS = {
             }
         ],
     },
-    'packages': ['PySide6', 'requests', 'sqlite3', 'certifi'],
+    'packages': ['PySide6', 'requests', 'sqlite3', 'certifi', 'matplotlib'],
     'includes': ['vanta_vuln_stats'],
-    'excludes': ['tkinter', 'matplotlib', 'numpy', 'pandas'],
+    'excludes': ['tkinter', 'numpy', 'pandas'],
     'semi_standalone': False,
     'site_packages': True,
 }
@@ -53,5 +53,6 @@ setup(
     install_requires=[
         'requests>=2.31.0',
         'PySide6>=6.7.0',
+        'matplotlib>=3.8.0',
     ],
 )

--- a/vanta_vuln_gui.py
+++ b/vanta_vuln_gui.py
@@ -21,6 +21,8 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from core.stats import VulnerabilityStats
 from gui.credentials_dialog import CredentialsDialog
 from gui.credentials_manager import CredentialsManager
+from gui.dashboard import DashboardWidget
+from gui.detail_panel import VulnerabilityDetailPanel
 from gui.models import VulnerabilitySortFilterProxyModel, VulnerabilityTableModel
 from gui.settings_manager import SettingsManager
 from gui.workers import APISyncWorker, DatabaseWorker, ThreadManager
@@ -122,6 +124,17 @@ class MainWindow(QtWidgets.QMainWindow):
         self.proxy_model = VulnerabilitySortFilterProxyModel()
         self.proxy_model.setSourceModel(self.vuln_model)
 
+        # Detail and dashboard widgets
+        self.detail_panel = VulnerabilityDetailPanel()
+        self.detail_panel.setMinimumWidth(320)
+        self.dashboard_widget = DashboardWidget()
+
+        # Live filter debounce timer
+        self._filter_timer = QtCore.QTimer(self)
+        self._filter_timer.setInterval(300)
+        self._filter_timer.setSingleShot(True)
+        self._filter_timer.timeout.connect(self.apply_filters)
+
         # Initialize settings manager
         self.settings_manager = SettingsManager()
 
@@ -153,7 +166,12 @@ class MainWindow(QtWidgets.QMainWindow):
         main_layout.addWidget(self._build_path_controls())
         main_layout.addWidget(self._build_filter_group())
         main_layout.addWidget(self._build_stats_group())
-        main_layout.addWidget(self._build_table())
+        content_splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+        content_splitter.addWidget(self._build_table())
+        content_splitter.addWidget(self.detail_panel)
+        content_splitter.setStretchFactor(0, 3)
+        content_splitter.setStretchFactor(1, 2)
+        main_layout.addWidget(content_splitter, 1)
         main_layout.addWidget(self._build_log_view())
 
     def _build_path_controls(self) -> QtWidgets.QGroupBox:
@@ -198,6 +216,8 @@ class MainWindow(QtWidgets.QMainWindow):
     def _build_filter_group(self) -> QtWidgets.QGroupBox:
         group = QtWidgets.QGroupBox("Filters")
         layout = QtWidgets.QGridLayout(group)
+        layout.setHorizontalSpacing(8)
+        layout.setVerticalSpacing(6)
 
         self.date_identified_start_edit = QtWidgets.QLineEdit()
         self.date_identified_start_edit.setPlaceholderText("YYYY-MM-DDTHH:MM:SSZ")
@@ -236,11 +256,55 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addWidget(QtWidgets.QLabel("Asset ID"), 6, 0)
         layout.addWidget(self.asset_edit, 6, 1, 1, 2)
 
+        button_layout = QtWidgets.QHBoxLayout()
+        self.clear_filters_button = QtWidgets.QPushButton("Clear Filters")
+        self.load_filter_button = QtWidgets.QPushButton("Load Preset…")
+        self.save_filter_button = QtWidgets.QPushButton("Save Preset")
+        button_layout.addWidget(self.clear_filters_button)
+        button_layout.addWidget(self.load_filter_button)
+        button_layout.addWidget(self.save_filter_button)
+        button_layout.addStretch()
+
+        layout.addLayout(button_layout, 7, 0, 1, 7)
+
+        self.clear_filters_button.clicked.connect(self._new_filter)
+        self.load_filter_button.clicked.connect(self._open_filter)
+        self.save_filter_button.clicked.connect(self._save_filter)
+
+        self._connect_filter_inputs()
+
         return group
 
+    def _connect_filter_inputs(self) -> None:
+        """Connect filter input widgets to live filtering."""
+        inputs = [
+            self.date_identified_start_edit,
+            self.date_identified_end_edit,
+            self.date_remediated_start_edit,
+            self.date_remediated_end_edit,
+            self.cve_edit,
+            self.asset_edit,
+        ]
+        for widget in inputs:
+            widget.textChanged.connect(self._on_filter_input_changed)
+
+        for checkbox in self.severity_checkboxes.values():
+            checkbox.stateChanged.connect(self._on_filter_input_changed)
+
+    def _on_filter_input_changed(self) -> None:
+        """Trigger a debounced filter application when inputs change."""
+        if not self.all_vulnerabilities:
+            return
+        self._filter_timer.start()
+
     def _build_stats_group(self) -> QtWidgets.QGroupBox:
-        group = QtWidgets.QGroupBox("Statistics")
-        layout = QtWidgets.QGridLayout(group)
+        group = QtWidgets.QGroupBox("Statistics & Dashboard")
+        layout = QtWidgets.QVBoxLayout(group)
+        layout.setSpacing(12)
+
+        metrics_grid = QtWidgets.QGridLayout()
+        metrics_grid.setHorizontalSpacing(12)
+        metrics_grid.setVerticalSpacing(6)
 
         self.stats_labels: Dict[str, QtWidgets.QLabel] = {}
         stat_fields = [
@@ -256,17 +320,20 @@ class MainWindow(QtWidgets.QMainWindow):
         for row, (key, label) in enumerate(stat_fields):
             widget = QtWidgets.QLabel("0")
             widget.setObjectName(key)
-            layout.addWidget(QtWidgets.QLabel(label), row, 0)
-            layout.addWidget(widget, row, 1)
+            metrics_grid.addWidget(QtWidgets.QLabel(label), row, 0)
+            metrics_grid.addWidget(widget, row, 1)
             self.stats_labels[key] = widget
 
         self.severity_stats: Dict[str, QtWidgets.QLabel] = {}
         severity_names = ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
         for idx, severity in enumerate(severity_names):
             label = QtWidgets.QLabel("0")
-            layout.addWidget(QtWidgets.QLabel(severity.title()), idx, 2)
-            layout.addWidget(label, idx, 3)
+            metrics_grid.addWidget(QtWidgets.QLabel(severity.title()), idx, 2)
+            metrics_grid.addWidget(label, idx, 3)
             self.severity_stats[severity] = label
+
+        layout.addLayout(metrics_grid)
+        layout.addWidget(self.dashboard_widget)
 
         return group
 
@@ -448,7 +515,10 @@ class MainWindow(QtWidgets.QMainWindow):
         return True
 
     def apply_filters(self) -> None:
+        self._filter_timer.stop()
         if not self.all_vulnerabilities:
+            self.dashboard_widget.clear()
+            self.detail_panel.display_vulnerability(None)
             self.append_log("No data loaded yet.")
             return
 
@@ -506,6 +576,8 @@ class MainWindow(QtWidgets.QMainWindow):
         for severity, label in self.severity_stats.items():
             label.setText(str(stats.get("by_severity", {}).get(severity, 0)))
 
+        self.dashboard_widget.update_data(stats, self.filtered_vulnerabilities)
+
     def _populate_table(self) -> None:
         """Populate the table with filtered vulnerability data using the model."""
         # Update the model with filtered data
@@ -513,6 +585,12 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Update the status bar
         self._update_status_bar()
+
+        if self.filtered_vulnerabilities:
+            self.table.selectRow(0)
+        else:
+            self.table.clearSelection()
+            self.detail_panel.display_vulnerability(None)
 
     def _export_filtered(self) -> None:
         if not self.filtered_vulnerabilities:
@@ -734,6 +812,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.asset_edit.clear()
         for checkbox in self.severity_checkboxes.values():
             checkbox.setChecked(False)
+        self._current_filter_name = None
         self.apply_filters()
         self.append_log("Filters cleared")
 
@@ -753,6 +832,7 @@ class MainWindow(QtWidgets.QMainWindow):
             filters = self.settings_manager.get_filter_preset(preset_name)
             if filters:
                 self._apply_filter_preset(filters)
+                self._current_filter_name = preset_name
                 self.append_log(f"Loaded filter preset: {preset_name}")
 
     def _save_filter(self) -> None:
@@ -1122,6 +1202,21 @@ Save commonly-used filter combinations with File → Save Filter.</p>
     def _on_selection_changed(self) -> None:
         """Handle table selection changes."""
         self._update_status_bar()
+
+        selection_model = self.table.selectionModel()
+        if not selection_model:
+            self.detail_panel.display_vulnerability(None)
+            return
+
+        selected_rows = selection_model.selectedRows()
+        if len(selected_rows) == 1:
+            source_index = self.proxy_model.mapToSource(selected_rows[0])
+            vuln = self.vuln_model.getVulnerability(source_index.row())
+            self.detail_panel.display_vulnerability(vuln)
+        elif len(selected_rows) > 1:
+            self.detail_panel.display_selection_summary(len(selected_rows))
+        else:
+            self.detail_panel.display_vulnerability(None)
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:
         """Handle window close event to save settings."""


### PR DESCRIPTION
## Summary
- add a reusable dashboard widget that renders KPI cards plus severity, integration, and trend charts
- introduce a vulnerability detail panel for the split view with rich metadata formatting
- integrate the new widgets into the main window with live filtering controls and update packaging to bundle matplotlib

## Testing
- python -m compileall vanta_vuln_gui.py gui

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69125319a7c08321b0cb667b05d21fa7)