### PR TITLE
Add severity styling and icons to vulnerability table

### DIFF
--- a/gui/icons/severity-critical.svg
+++ b/gui/icons/severity-critical.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Critical severity">
+  <title>Critical severity</title>
+  <circle cx="12" cy="12" r="10" fill="#C82333" />
+  <rect x="11" y="6" width="2" height="9" rx="1" fill="#FFFFFF" />
+  <rect x="11" y="17" width="2" height="2" rx="1" fill="#FFFFFF" />
+</svg>

--- a/gui/icons/severity-high.svg
+++ b/gui/icons/severity-high.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="High severity">
+  <title>High severity</title>
+  <polygon points="12,3 22,21 2,21" fill="#FD7E14" />
+  <rect x="11" y="9" width="2" height="8" rx="1" fill="#FFFFFF" />
+  <rect x="11" y="18" width="2" height="2" rx="1" fill="#FFFFFF" />
+</svg>

--- a/gui/icons/severity-low.svg
+++ b/gui/icons/severity-low.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Low severity">
+  <title>Low severity</title>
+  <rect x="3" y="4" width="18" height="16" rx="3" fill="#0D6EFD" />
+  <path d="M9.5 12.5 L11.5 14.5 L15 10.5" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+</svg>

--- a/gui/icons/severity-medium.svg
+++ b/gui/icons/severity-medium.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Medium severity">
+  <title>Medium severity</title>
+  <path d="M12 2 L22 12 L12 22 L2 12 Z" fill="#FFC107" />
+  <rect x="11" y="8" width="2" height="8" rx="1" fill="#4A4A4A" />
+  <rect x="11" y="17" width="2" height="2" rx="1" fill="#4A4A4A" />
+</svg>


### PR DESCRIPTION
## Summary
- add severity-specific colors and icons for the vulnerability table model to improve readability and accessibility
- include SVG icons for each severity level so the GUI can render shape-based cues alongside colors

## Testing
- python -m compileall gui/models.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69125319a7c08321b0cb667b05d21fa7)