### PR TITLE
Handle Python 3.14 incompatibility in macOS build script

### DIFF
--- a/MACOS_APP_BUILD.md
+++ b/MACOS_APP_BUILD.md
@@ -5,7 +5,7 @@ This guide explains how to package the Vanta Vulnerability Statistics utility as
 ## Prerequisites
 
 - **macOS** system (for final build)
-- **Python 3.8+** installed
+- **Python 3.8+** installed (Python 3.12 or 3.13 recommended for the GUI build)
 - **Xcode Command Line Tools** (install via: `xcode-select --install`)
 
 ## Quick Start
@@ -129,6 +129,12 @@ Make sure you've installed dependencies:
 ```bash
 pip install -r requirements.txt
 ```
+
+If the dependency installation fails with messages about unsupported Python
+versions, ensure you are using Python 3.12 or 3.13. PySide6 does not yet ship
+prebuilt wheels for Python 3.14, so installing with a newer interpreter will
+fail. Install an older Python (for example via `brew install python@3.12`) and
+rerun the build.
 
 ### App Won't Open: "App is damaged"
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ This creates a native macOS application at `dist/vanta_vuln_gui.app` that you ca
 - Copy to your Applications folder
 - Distribute to other macOS users (via DMG)
 
+> **Python version note:** PySide6 (the Qt binding used by the GUI) does not
+> currently publish wheels for Python 3.14. Use Python 3.12 or 3.13 when
+> running the build script to avoid dependency installation failures.
+
 **For detailed instructions**, see [MACOS_APP_BUILD.md](MACOS_APP_BUILD.md) which covers:
 - Building the app bundle
 - Creating a custom icon

--- a/build_macos_app.sh
+++ b/build_macos_app.sh
@@ -22,7 +22,24 @@ fi
 # Check Python version
 echo "Checking Python version..."
 PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
 echo "Found Python $PYTHON_VERSION"
+
+if [ "$PYTHON_MAJOR" -eq 3 ] && [ "$PYTHON_MINOR" -ge 14 ]; then
+    echo ""
+    echo "ERROR: Python $PYTHON_VERSION is not supported for building the GUI."
+    echo "PySide6 has not yet published wheels for Python 3.14, so the dependency"
+    echo "installation will fail. Please install Python 3.12 or 3.13 and re-run"
+    echo "this script using that interpreter."
+    echo ""
+    echo "Recommended steps on macOS:"
+    echo "  1. brew install python@3.12"
+    echo "  2. python3.12 -m venv venv"
+    echo "  3. source venv/bin/activate"
+    echo "  4. ./build_macos_app.sh"
+    exit 1
+fi
 echo ""
 
 # Create virtual environment if it doesn't exist

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests>=2.31.0
+# PySide6 currently ships wheels only for Python < 3.14.
 PySide6>=6.7.0
 py2app>=0.28.0
 


### PR DESCRIPTION
## Summary
- fail fast in the macOS build script when Python 3.14+ is detected and provide downgrade guidance
- document the recommended Python versions and troubleshooting steps for GUI builds
- note the PySide6 Python version limitation in the requirements file

## Testing
- no tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691261c2a448832195a9301a5b235984)