### PR TITLE
Fix macOS build dependency for Vanta Vuln Stats app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests>=2.31.0
 # PySide6 currently ships wheels only for Python < 3.14.
 PySide6>=6.7.0
+matplotlib>=3.8.0
 py2app>=0.28.0
 
 # Optional Lambda dependencies (install separately if deploying to Lambda)


### PR DESCRIPTION
## Summary
- add matplotlib to the primary requirements list so py2app can resolve GUI dependencies during macOS builds

## Testing
- not run (dependency-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69126358354483218e23d997e73b38dd)