### PR TITLE
Update better-sqlite3 dependency for Node 24 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",
-        "better-sqlite3": "^9.4.1",
+        "better-sqlite3": "^12.4.1",
         "dayjs": "^1.11.10",
         "electron-store": "^8.1.0"
       },
@@ -1058,14 +1058,17 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
-      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
+      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bindings": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "axios": "^1.6.8",
-    "better-sqlite3": "^9.4.1",
+    "better-sqlite3": "^12.4.1",
     "dayjs": "^1.11.10",
     "electron-store": "^8.1.0"
   }


### PR DESCRIPTION
## Summary
- update better-sqlite3 to 12.4.1 to provide prebuilt binaries compatible with Node 24

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912a8ec1c9083218dbefe801ee226c7)