### PR TITLE
Rebuild native modules after install to fix better-sqlite3 mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,16 @@ The app replaces the legacy Python CLI/Qt tooling with a modern JavaScript stack
 
 ### Installation
 
-1. Install dependencies:
+1. Install dependencies (this will also rebuild native modules for the bundled Electron runtime):
 
    ```bash
    npm install
+   ```
+
+   If you ever encounter native module version errors (for example with `better-sqlite3`) you can manually rerun the rebuild step:
+
+   ```bash
+   npm run postinstall
    ```
 
 2. Launch the Electron application in development mode:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "vanta-vuln-stats-electron",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.8",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "electron .",
     "lint": "echo 'No linting configured'",
+    "postinstall": "electron-builder install-app-deps",
     "pack": "electron-builder --dir",
     "dist": "electron-builder"
   },


### PR DESCRIPTION
## Summary
- add a postinstall script that rebuilds native dependencies against the Electron runtime
- document the native module rebuild step in the installation instructions so developers can rerun it when needed

## Testing
- npm install

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912c436f93c8321ab5a817b993ce645)