### PR TITLE
Configure macOS app bundle packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,15 @@ Electron Builder is pre-configured for packaging. Run one of the following comma
   npm run dist
   ```
 
-Refer to the [Electron Builder documentation](https://www.electron.build/) for customizing icons, signing, and advanced packaging options.
+#### Creating a macOS `.app` bundle
+
+To generate the macOS application bundle (`Vanta Vulnerability Stats.app`) run the dedicated packaging script on a macOS host:
+
+```bash
+npm run package:mac
+```
+
+This command emits the unsigned `.app` bundle to `dist/mac/`. Because Electron Builder cannot cross-compile macOS applications from Windows or Linux, the script must be executed on macOS (you can still run `npm install` on other platforms beforehand). If you need to notarize or code-sign the build, supply the appropriate environment variables documented in the [Electron Builder macOS guide](https://www.electron.build/code-signing#macos). Refer to the broader [Electron Builder documentation](https://www.electron.build/) for customizing icons, signing, and advanced packaging options.
 
 ## Application Architecture
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "echo 'No linting configured'",
     "postinstall": "electron-builder install-app-deps",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "dist": "electron-builder",
+    "package:mac": "electron-builder --mac dir"
   },
   "author": "",
   "license": "MIT",
@@ -21,5 +22,26 @@
     "better-sqlite3": "^12.4.1",
     "dayjs": "^1.11.10",
     "electron-store": "^8.1.0"
+  },
+  "build": {
+    "appId": "com.vanta.vulnstats",
+    "productName": "Vanta Vulnerability Stats",
+    "asar": true,
+    "files": [
+      "**/*",
+      "!dist/**/*"
+    ],
+    "mac": {
+      "category": "public.app-category.developer-tools",
+      "target": [
+        "dir"
+      ]
+    },
+    "directories": {
+      "output": "dist"
+    },
+    "extraMetadata": {
+      "main": "src/main/main.js"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add an electron-builder macOS target and metadata so the project outputs a `.app` bundle
- document how to run the mac-specific packaging script and the requirement to build on macOS

## Testing
- npm run pack

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912c7168bc08321a64a9c777fd4eaba)