### PR TITLE
Add sync control features (start, stop, pause, resume)

### DIFF
--- a/src/core/apiClient.js
+++ b/src/core/apiClient.js
@@ -65,6 +65,11 @@ class VantaApiClient {
       try {
         return await this.http.request(config);
       } catch (error) {
+        // Check if request was aborted
+        if (error.name === 'AbortError' || error.code === 'ERR_CANCELED') {
+          throw error;
+        }
+
         const status = error?.response?.status;
         if (status === 401 && attempt < retries) {
           await this.authenticate(true);

--- a/src/main/dataService.js
+++ b/src/main/dataService.js
@@ -20,6 +20,12 @@ class DataService {
     this.databasePath = path.join(app.getPath('userData'), 'storage', 'vanta_vulnerabilities.db');
     this.database = new VulnerabilityDatabase(this.databasePath);
     this.activeSync = null;
+    this.syncState = {
+      state: 'idle', // idle, running, paused, stopping
+      abortController: null,
+      pausePromiseResolve: null,
+      isPaused: false,
+    };
   }
 
   getCredentials() {
@@ -33,7 +39,7 @@ class DataService {
     return merged;
   }
 
-  async syncData(progressCallback) {
+  async syncData(progressCallback, stateCallback) {
     if (this.activeSync) {
       throw new Error('A sync is already in progress.');
     }
@@ -53,24 +59,50 @@ class DataService {
     };
 
     this.activeSync = syncState;
+    this.syncState.state = 'running';
+    this.syncState.abortController = new AbortController();
+    this.syncState.isPaused = false;
+    stateCallback?.('running');
 
     try {
       const vulnerabilities = [];
       const remediations = [];
 
+      // Helper to check for pause/stop
+      const checkPauseOrStop = async () => {
+        // Check if stopping
+        if (this.syncState.abortController.signal.aborted) {
+          throw new Error('Sync stopped by user');
+        }
+
+        // Check if paused
+        if (this.syncState.isPaused) {
+          stateCallback?.('paused');
+          // Wait until resumed or stopped
+          await new Promise((resolve) => {
+            this.syncState.pausePromiseResolve = resolve;
+          });
+          stateCallback?.('running');
+        }
+      };
+
       // Fetch vulnerabilities and remediations in parallel for faster sync
       await Promise.all([
         apiClient.getVulnerabilities({
           onBatch: async (batch) => {
+            await checkPauseOrStop();
             vulnerabilities.push(...batch);
             progressCallback?.({ type: 'vulnerabilities', count: vulnerabilities.length });
           },
+          signal: this.syncState.abortController.signal,
         }),
         apiClient.getRemediations({
           onBatch: async (batch) => {
+            await checkPauseOrStop();
             remediations.push(...batch);
             progressCallback?.({ type: 'remediations', count: remediations.length });
           },
+          signal: this.syncState.abortController.signal,
         }),
       ]);
 
@@ -81,9 +113,69 @@ class DataService {
         vulnerabilities: vulnerabilityStats,
         remediations: remediationStats,
       };
+    } catch (error) {
+      if (error.message === 'Sync stopped by user') {
+        stateCallback?.('idle');
+        throw error;
+      }
+      throw error;
     } finally {
       this.activeSync = null;
+      this.syncState.state = 'idle';
+      this.syncState.abortController = null;
+      this.syncState.pausePromiseResolve = null;
+      this.syncState.isPaused = false;
+      stateCallback?.('idle');
     }
+  }
+
+  pauseSync() {
+    if (this.syncState.state !== 'running') {
+      throw new Error('No active sync to pause.');
+    }
+    this.syncState.isPaused = true;
+    this.syncState.state = 'paused';
+    return { success: true };
+  }
+
+  resumeSync() {
+    if (this.syncState.state !== 'paused') {
+      throw new Error('Sync is not paused.');
+    }
+    this.syncState.isPaused = false;
+    this.syncState.state = 'running';
+    if (this.syncState.pausePromiseResolve) {
+      this.syncState.pausePromiseResolve();
+      this.syncState.pausePromiseResolve = null;
+    }
+    return { success: true };
+  }
+
+  stopSync() {
+    if (!this.activeSync) {
+      throw new Error('No active sync to stop.');
+    }
+    this.syncState.state = 'stopping';
+
+    // If paused, resolve the pause promise first
+    if (this.syncState.pausePromiseResolve) {
+      this.syncState.pausePromiseResolve();
+      this.syncState.pausePromiseResolve = null;
+    }
+
+    // Abort the sync
+    if (this.syncState.abortController) {
+      this.syncState.abortController.abort();
+    }
+
+    return { success: true };
+  }
+
+  getSyncState() {
+    return {
+      state: this.syncState.state,
+      hasActiveSync: !!this.activeSync,
+    };
   }
 
   getStatistics(filters) {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -61,8 +61,12 @@ ipcMain.handle('sync:run', async () => {
     mainWindow.webContents.send('sync:progress', progress);
   };
 
+  const stateEmitter = (state) => {
+    mainWindow.webContents.send('sync:state', { state });
+  };
+
   try {
-    const result = await dataService.syncData(progressEmitter);
+    const result = await dataService.syncData(progressEmitter, stateEmitter);
     mainWindow.webContents.send('sync:completed', result);
     return result;
   } catch (error) {
@@ -70,3 +74,11 @@ ipcMain.handle('sync:run', async () => {
     throw error;
   }
 });
+
+ipcMain.handle('sync:pause', () => dataService.pauseSync());
+
+ipcMain.handle('sync:resume', () => dataService.resumeSync());
+
+ipcMain.handle('sync:stop', () => dataService.stopSync());
+
+ipcMain.handle('sync:state', () => dataService.getSyncState());

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -16,7 +16,12 @@ contextBridge.exposeInMainWorld('vanta', {
   getSyncHistory: () => ipcRenderer.invoke('sync:history'),
   getDatabasePath: () => ipcRenderer.invoke('database:path'),
   runSync: () => ipcRenderer.invoke('sync:run'),
+  pauseSync: () => ipcRenderer.invoke('sync:pause'),
+  resumeSync: () => ipcRenderer.invoke('sync:resume'),
+  stopSync: () => ipcRenderer.invoke('sync:stop'),
+  getSyncState: () => ipcRenderer.invoke('sync:state'),
   onSyncProgress: createSubscription('sync:progress'),
   onSyncCompleted: createSubscription('sync:completed'),
   onSyncError: createSubscription('sync:error'),
+  onSyncState: createSubscription('sync:state'),
 });

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -14,7 +14,12 @@
       <p class="subtitle">Synchronize vulnerabilities from the Vanta API and explore rich statistics locally.</p>
     </div>
     <div class="header-actions">
-      <button id="syncButton" class="primary">Run Sync</button>
+      <div class="sync-controls">
+        <button id="startSyncButton" class="primary">Start Sync</button>
+        <button id="pauseSyncButton" class="secondary" style="display: none;">Pause</button>
+        <button id="resumeSyncButton" class="secondary" style="display: none;">Resume</button>
+        <button id="stopSyncButton" class="danger" style="display: none;">Stop</button>
+      </div>
       <span id="syncStatus" class="status"></span>
     </div>
   </header>

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -5,7 +5,10 @@ const elements = {
   clientSecret: document.getElementById('clientSecret'),
   saveCredentials: document.getElementById('saveCredentials'),
   credentialsStatus: document.getElementById('credentialsStatus'),
-  syncButton: document.getElementById('syncButton'),
+  startSyncButton: document.getElementById('startSyncButton'),
+  pauseSyncButton: document.getElementById('pauseSyncButton'),
+  resumeSyncButton: document.getElementById('resumeSyncButton'),
+  stopSyncButton: document.getElementById('stopSyncButton'),
   syncStatus: document.getElementById('syncStatus'),
   statistics: document.getElementById('statistics'),
   syncHistoryBody: document.getElementById('syncHistoryBody'),
@@ -50,7 +53,7 @@ const state = {
   total: 0,
   vulnerabilities: [],
   selectedId: null,
-  syncing: false,
+  syncState: 'idle', // idle, running, paused, stopping
 };
 
 const toISODate = (value) => {
@@ -77,6 +80,34 @@ const formatDateTime = (value) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return value;
   return date.toLocaleString();
+};
+
+const updateSyncButtons = (syncState) => {
+  state.syncState = syncState;
+
+  // Hide all buttons first
+  elements.startSyncButton.style.display = 'none';
+  elements.pauseSyncButton.style.display = 'none';
+  elements.resumeSyncButton.style.display = 'none';
+  elements.stopSyncButton.style.display = 'none';
+
+  // Show appropriate buttons based on state
+  switch (syncState) {
+    case 'idle':
+      elements.startSyncButton.style.display = 'inline-block';
+      break;
+    case 'running':
+      elements.pauseSyncButton.style.display = 'inline-block';
+      elements.stopSyncButton.style.display = 'inline-block';
+      break;
+    case 'paused':
+      elements.resumeSyncButton.style.display = 'inline-block';
+      elements.stopSyncButton.style.display = 'inline-block';
+      break;
+    case 'stopping':
+      // No buttons shown while stopping
+      break;
+  }
 };
 
 const renderStatistics = (stats) => {
@@ -314,19 +345,52 @@ const attachEventListeners = () => {
     }, 2500);
   });
 
-  elements.syncButton.addEventListener('click', async () => {
-    if (state.syncing) {
+  elements.startSyncButton.addEventListener('click', async () => {
+    if (state.syncState !== 'idle') {
       return;
     }
-    state.syncing = true;
-    elements.syncButton.disabled = true;
-    elements.syncStatus.textContent = 'Syncing…';
+    elements.syncStatus.textContent = 'Starting sync…';
     try {
       await window.vanta.runSync();
     } catch (error) {
       elements.syncStatus.textContent = `Sync failed: ${error.message}`;
-      state.syncing = false;
-      elements.syncButton.disabled = false;
+      updateSyncButtons('idle');
+    }
+  });
+
+  elements.pauseSyncButton.addEventListener('click', async () => {
+    if (state.syncState !== 'running') {
+      return;
+    }
+    try {
+      await window.vanta.pauseSync();
+      elements.syncStatus.textContent = 'Sync paused.';
+    } catch (error) {
+      elements.syncStatus.textContent = `Failed to pause: ${error.message}`;
+    }
+  });
+
+  elements.resumeSyncButton.addEventListener('click', async () => {
+    if (state.syncState !== 'paused') {
+      return;
+    }
+    try {
+      await window.vanta.resumeSync();
+      elements.syncStatus.textContent = 'Sync resumed…';
+    } catch (error) {
+      elements.syncStatus.textContent = `Failed to resume: ${error.message}`;
+    }
+  });
+
+  elements.stopSyncButton.addEventListener('click', async () => {
+    if (state.syncState !== 'running' && state.syncState !== 'paused') {
+      return;
+    }
+    try {
+      await window.vanta.stopSync();
+      elements.syncStatus.textContent = 'Stopping sync…';
+    } catch (error) {
+      elements.syncStatus.textContent = `Failed to stop: ${error.message}`;
     }
   });
 
@@ -360,6 +424,10 @@ const attachEventListeners = () => {
 
   elements.vulnerabilityTable.addEventListener('click', handleTableClick);
 
+  window.vanta.onSyncState(({ state: newState }) => {
+    updateSyncButtons(newState);
+  });
+
   window.vanta.onSyncProgress(({ type, count }) => {
     const label = type === 'vulnerabilities' ? 'Vulnerabilities' : 'Remediations';
     elements.syncStatus.textContent = `Syncing ${label}: ${formatNumber(count)} records processed…`;
@@ -367,8 +435,7 @@ const attachEventListeners = () => {
 
   window.vanta.onSyncCompleted(async () => {
     elements.syncStatus.textContent = 'Sync complete! Refreshing data…';
-    state.syncing = false;
-    elements.syncButton.disabled = false;
+    updateSyncButtons('idle');
     await Promise.all([loadStatistics(), loadVulnerabilities(), loadSyncHistory()]);
     elements.syncStatus.textContent = 'Sync complete.';
     setTimeout(() => {
@@ -378,8 +445,7 @@ const attachEventListeners = () => {
 
   window.vanta.onSyncError((payload) => {
     elements.syncStatus.textContent = `Sync failed: ${payload?.message || 'Unknown error'}`;
-    state.syncing = false;
-    elements.syncButton.disabled = false;
+    updateSyncButtons('idle');
   });
 };
 
@@ -388,6 +454,10 @@ const initialize = async () => {
   await loadVulnerabilities();
   populateFilterInputs();
   attachEventListeners();
+
+  // Initialize button state
+  const syncState = await window.vanta.getSyncState();
+  updateSyncButtons(syncState.state);
 };
 
 initialize().catch((error) => {

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -86,9 +86,20 @@ button.link {
   padding: 0.25rem 0.5rem;
 }
 
+button.danger {
+  background: var(--color-danger);
+  color: white;
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(249, 115, 22, 0.35);
+}
+
 button:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px rgba(56, 189, 248, 0.2);
+}
+
+button.danger:hover {
+  box-shadow: 0 16px 32px rgba(249, 115, 22, 0.4);
 }
 
 button:disabled {
@@ -96,6 +107,11 @@ button:disabled {
   cursor: not-allowed;
   transform: none;
   box-shadow: none;
+}
+
+.sync-controls {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .status {


### PR DESCRIPTION
## Summary

Implemented comprehensive sync control functionality allowing users to start, stop, pause, and resume sync operations. Added a state machine that manages sync lifecycle with context-aware UI buttons that display based on the current state.

## Key Changes

- **Backend**: Added sync state management with AbortController support in dataService.js, supporting idle/running/paused/stopping states
- **IPC**: Added handlers for pause, resume, stop operations and state synchronization
- **Frontend**: Replaced single "Run Sync" button with context-aware controls that show appropriate buttons based on sync state
- **API Client**: Added abort signal handling to gracefully stop in-flight requests

## State Machine

- **idle**: Show "Start Sync" button
- **running**: Show "Pause" and "Stop" buttons  
- **paused**: Show "Resume" and "Stop" buttons
- **stopping**: No buttons shown (transitional state)