### PR TITLE
Convert sync history into log console

### DIFF
--- a/src/core/database.js
+++ b/src/core/database.js
@@ -595,7 +595,12 @@ class VulnerabilityDatabase {
     });
   }
 
-  getSyncHistory(limit = 20) {
+  getSyncHistory(limit = 100000) {
+    const MAX_HISTORY = 100000;
+    const requested = Number(limit);
+    const safeLimit = Number.isFinite(requested) ? requested : MAX_HISTORY;
+    const finalLimit = Math.min(Math.max(safeLimit, 1), MAX_HISTORY);
+
     const stmt = this.db.prepare(`
       SELECT
         sync_date,
@@ -606,7 +611,7 @@ class VulnerabilityDatabase {
       ORDER BY sync_date DESC
       LIMIT ?
     `);
-    return stmt.all(limit);
+    return stmt.all(finalLimit);
   }
 }
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -62,7 +62,7 @@
       <article class="card">
         <header class="card__header">
           <h2>Sync History</h2>
-          <p>Individual sync operations for vulnerabilities and remediations.</p>
+          <p>Chronological log of sync activity with timestamped entries.</p>
         </header>
         <div class="card__body">
           <div id="syncHistoryLog" class="sync-history-log"></div>

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -129,69 +129,33 @@ button:disabled {
 .sync-history-log {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 0.5rem;
   max-height: 400px;
-  overflow-y: auto;
-}
-
-.sync-history-item {
   padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 8px;
-  background: rgba(30, 41, 59, 0.5);
-  border: 1px solid rgba(148, 163, 184, 0.1);
-}
-
-.sync-history-item.in-progress {
-  border-left: 3px solid #3b82f6;
-  background: rgba(59, 130, 246, 0.1);
-}
-
-.sync-history-item.completed {
-  border-left: 3px solid #10b981;
-}
-
-.sync-history-item.failed {
-  border-left: 3px solid #ef4444;
-}
-
-.sync-history-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.sync-history-title {
-  font-weight: 600;
-  color: rgba(226, 232, 240, 0.95);
-  font-size: 0.9rem;
-}
-
-.sync-history-time {
-  color: rgba(148, 163, 184, 0.7);
+  overflow-y: auto;
+  font-family: 'SFMono-Regular', 'Roboto Mono', Menlo, Consolas, monospace;
   font-size: 0.85rem;
+  line-height: 1.4;
 }
 
-.sync-history-stats {
+.sync-log-line {
   display: flex;
-  gap: 1rem;
-  font-size: 0.85rem;
+  gap: 0.75rem;
+  align-items: flex-start;
+  white-space: pre-wrap;
+}
+
+.sync-log-timestamp {
   color: rgba(148, 163, 184, 0.8);
+  flex-shrink: 0;
 }
 
-.sync-history-stat {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-}
-
-.sync-history-stat-label {
-  color: rgba(148, 163, 184, 0.6);
-}
-
-.sync-history-stat-value {
-  color: rgba(226, 232, 240, 0.9);
-  font-weight: 500;
+.sync-log-message {
+  color: rgba(226, 232, 240, 0.95);
+  flex: 1;
 }
 
 .sync-history-empty {


### PR DESCRIPTION
Turn the Sync History panel into a timestamped console log so users can skim sequential updates. Raise the SQLite history retention and refresh the renderer copy/styles to match.