### PR TITLE
Fix Mermaid diagram syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,19 @@ graph TB
     Preload -->|Secure Bridge| Main
 
     %% Main Process Coordination
-    Main -->|sync:run<br/>stats:get<br/>vulnerabilities:list| DataService
-    Main -->|sync:progress<br/>sync:incremental| UI
+    Main -->|"sync:run
+    stats:get
+    vulnerabilities:list"| DataService
+    Main -->|"sync:progress
+    sync:incremental"| UI
 
     %% Data Service Orchestration
-    DataService -->|authenticate()<br/>getVulnerabilities()<br/>getRemediations()| ApiClient
-    DataService -->|storeVulnerabilitiesBatch()<br/>getStatistics()<br/>getVulnerabilities()| Database
+    DataService -->|"authenticate()
+    getVulnerabilities()
+    getRemediations()"| ApiClient
+    DataService -->|"storeVulnerabilitiesBatch()
+    getStatistics()
+    getVulnerabilities()"| Database
     DataService -->|formatStatistics()| Stats
     DataService -->|get/set credentials| Store
 


### PR DESCRIPTION
## Summary
Fixed Mermaid diagram parse error by replacing `<br/>` HTML tags with proper multi-line label syntax. GitHub's Mermaid renderer expects quoted strings with actual line breaks in edge labels.

## Changes
- Updated architecture diagram edge labels (lines 126-139) to use quoted multi-line strings instead of HTML tags
- Diagram now renders correctly on GitHub without parse errors

## Test Plan
- [x] Verified diagram renders without parse errors on GitHub
- [x] All edge labels display correctly on multiple lines