### PR TITLE
Fix Mermaid diagram syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,19 +123,12 @@ graph TB
     Preload -->|Secure Bridge| Main
 
     %% Main Process Coordination
-    Main -->|"sync:run
-    stats:get
-    vulnerabilities:list"| DataService
-    Main -->|"sync:progress
-    sync:incremental"| UI
+    Main -->|"sync:run<br/>stats:get<br/>vulnerabilities:list"| DataService
+    Main -->|"sync:progress<br/>sync:incremental"| UI
 
     %% Data Service Orchestration
-    DataService -->|"authenticate()
-    getVulnerabilities()
-    getRemediations()"| ApiClient
-    DataService -->|"storeVulnerabilitiesBatch()
-    getStatistics()
-    getVulnerabilities()"| Database
+    DataService -->|"authenticate()<br/>getVulnerabilities()<br/>getRemediations()"| ApiClient
+    DataService -->|"storeVulnerabilitiesBatch()<br/>getStatistics()<br/>getVulnerabilities()"| Database
     DataService -->|formatStatistics()| Stats
     DataService -->|get/set credentials| Store
 


### PR DESCRIPTION
## Summary
Fixed a Mermaid diagram parsing error caused by multi-line edge labels in the architecture diagram. The parser doesn't support source code line breaks within labels, so they've been converted to single-line labels using `<br/>` tags for formatting.

## Test plan
- [x] Verify the README diagram renders correctly on GitHub
- [x] Confirm the diagram layout and labels are preserved