### PR TITLE
Handle 500 errors with valid pagination data

### DIFF
--- a/src/core/apiClient.js
+++ b/src/core/apiClient.js
@@ -121,26 +121,14 @@ class VantaApiClient {
           continue;
         }
 
-        // Check if 500 error response contains pagination info indicating end of results
-        // Some API implementations may return 500 with valid pagination data when there are no more pages
+        // Log 500 error response for debugging - helps diagnose API behavior
+        // DO NOT automatically treat as success - real errors must surface
         if (status && status >= 500 && error?.response?.data) {
           const errorBody = error.response.data;
-          const errorPageInfo = errorBody?.results?.pageInfo ?? {};
-
-          // Log the error response structure for debugging
           console.warn(
-            `[VantaApiClient] ${endpoint} returned ${status}. Error response data:`,
+            `[VantaApiClient] ${endpoint} returned ${status}. Error response:`,
             JSON.stringify(errorBody, null, 2),
           );
-
-          // If the error response explicitly indicates no more pages, treat as end of pagination
-          if (errorPageInfo.hasNextPage === false) {
-            console.warn(
-              `[VantaApiClient] ${endpoint} pagination complete (hasNextPage=false in error response). Returning ${results.length} total results.`,
-            );
-            // Exit the pagination loop by not setting pageCursor
-            break;
-          }
         }
 
         const requestId =

--- a/test/apiClient.test.js
+++ b/test/apiClient.test.js
@@ -1,0 +1,386 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { VantaApiClient } = require('../src/core/apiClient');
+
+// Mock axios module
+const axios = require('axios');
+const originalAxios = { ...axios };
+const originalCreate = axios.create;
+
+function resetAxiosMocks() {
+  axios.create = originalCreate;
+  axios.post = originalAxios.post;
+}
+
+test('VantaApiClient paginate reduces page size on 500 errors', async () => {
+  // Track page sizes attempted
+  const pageSizesAttempted = [];
+  let attemptCount = 0;
+
+  const mockAxiosInstance = {
+    request: async (config) => {
+      attemptCount++;
+      pageSizesAttempted.push(config.params.pageSize);
+
+      // Fail for the first 7 attempts (more than requestWithRetry's 6 attempts)
+      // to trigger page size reduction
+      if (attemptCount <= 7) {
+        const error = new Error('Server error');
+        error.response = {
+          status: 500,
+          data: { error: 'Internal server error' },
+          headers: {},
+        };
+        throw error;
+      }
+
+      // Eventually succeed
+      return {
+        data: {
+          results: {
+            data: [],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      };
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  // Suppress console warnings
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+
+  // Override sleep to make test fast
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => fn();
+
+  try {
+    await apiClient.paginate({
+      endpoint: '/test',
+      params: { pageSize: 4 },
+    });
+
+    // Should have logged page size reductions
+    const sizeReductionLogs = warnings.filter(w =>
+      w.some(arg => typeof arg === 'string' && arg.includes('Retrying with pageSize'))
+    );
+    assert.ok(sizeReductionLogs.length > 0, 'Should log page size reductions');
+  } finally {
+    console.warn = originalWarn;
+    global.setTimeout = originalSetTimeout;
+    resetAxiosMocks();
+  }
+});
+
+test('VantaApiClient paginate successfully handles multi-page responses', async () => {
+  let pageCount = 0;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      pageCount++;
+      if (pageCount === 1) {
+        return {
+          data: {
+            results: {
+              data: [{ id: 1 }, { id: 2 }],
+              pageInfo: {
+                hasNextPage: true,
+                endCursor: 'cursor1',
+              },
+            },
+          },
+        };
+      } else {
+        return {
+          data: {
+            results: {
+              data: [{ id: 3 }],
+              pageInfo: {
+                hasNextPage: false,
+              },
+            },
+          },
+        };
+      }
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  const results = await apiClient.paginate({
+    endpoint: '/test',
+    params: { pageSize: 10 },
+  });
+
+  assert.deepEqual(results, [{ id: 1 }, { id: 2 }, { id: 3 }]);
+  assert.equal(pageCount, 2);
+
+  resetAxiosMocks();
+});
+
+test('VantaApiClient paginate calls onBatch for each page', async () => {
+  let pageCount = 0;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      pageCount++;
+      return {
+        data: {
+          results: {
+            data: pageCount === 1 ? [{ id: 1 }] : [{ id: 2 }],
+            pageInfo: {
+              hasNextPage: pageCount < 2,
+              endCursor: pageCount < 2 ? 'cursor1' : undefined,
+            },
+          },
+        },
+      };
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  const batches = [];
+  await apiClient.paginate({
+    endpoint: '/test',
+    onBatch: async (batch) => batches.push(batch),
+  });
+
+  assert.equal(batches.length, 2);
+  assert.deepEqual(batches[0], [{ id: 1 }]);
+  assert.deepEqual(batches[1], [{ id: 2 }]);
+
+  resetAxiosMocks();
+});
+
+test('VantaApiClient paginate logs 500 error response for debugging', async () => {
+  let callCount = 0;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      callCount++;
+      const error = new Error('Server error');
+      error.response = {
+        status: 500,
+        data: {
+          error: 'Database connection failed',
+          details: 'Connection timeout',
+        },
+        headers: {
+          'x-request-id': 'req-123',
+        },
+      };
+      throw error;
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  // Capture console warnings
+  const originalWarn = console.warn;
+  const warnings = [];
+  console.warn = (...args) => warnings.push(args);
+
+  // Override sleep to make test fast
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => fn();
+
+  try {
+    await apiClient.paginate({
+      endpoint: '/test-endpoint',
+      params: { pageSize: 1 },
+    });
+    assert.fail('Should have thrown an error');
+  } catch (error) {
+    // Verify the error was thrown
+    assert.match(error.message, /Failed to paginate Vanta API/);
+
+    // Verify error response was logged for debugging BEFORE throwing
+    const errorResponseLogs = warnings.filter(w =>
+      w.some(arg => typeof arg === 'string' && arg.includes('Error response'))
+    );
+    assert.ok(errorResponseLogs.length > 0, 'Should log error response data before throwing');
+
+    // Verify the logged data contains the error details
+    const loggedData = errorResponseLogs.flatMap(w => w).join(' ');
+    assert.match(loggedData, /Database connection failed/);
+  } finally {
+    console.warn = originalWarn;
+    global.setTimeout = originalSetTimeout;
+    resetAxiosMocks();
+  }
+});
+
+test('VantaApiClient paginate does not mask legitimate 500 errors', async () => {
+  let callCount = 0;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      callCount++;
+      // Fail consistently to ensure error is thrown eventually
+      // After requestWithRetry exhausts retries (6 attempts), it should throw
+      const error = new Error('Server error');
+      error.response = {
+        status: 500,
+        data: {
+          error: 'Rate limit exceeded',
+        },
+        headers: {},
+      };
+      throw error;
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  // Suppress warnings
+  const originalWarn = console.warn;
+  console.warn = () => {};
+
+  // Override sleep to make test fast
+  const originalSetTimeout = global.setTimeout;
+  global.setTimeout = (fn) => fn();
+
+  try {
+    await apiClient.paginate({
+      endpoint: '/test',
+      params: { pageSize: 1 },
+    });
+    assert.fail('Should have thrown an error for legitimate 500');
+  } catch (error) {
+    // Error should be thrown, not masked
+    assert.match(error.message, /Failed to paginate Vanta API/);
+    // Verify multiple retries occurred
+    assert.ok(callCount > 1, 'Should have retried multiple times');
+  } finally {
+    console.warn = originalWarn;
+    global.setTimeout = originalSetTimeout;
+    resetAxiosMocks();
+  }
+});
+
+test('VantaApiClient getVulnerabilities calls paginate with correct endpoint', async () => {
+  let capturedConfig = null;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      capturedConfig = config;
+      return {
+        data: {
+          results: {
+            data: [{ id: 1 }],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      };
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  await apiClient.getVulnerabilities();
+
+  assert.equal(capturedConfig.url, '/vulnerabilities');
+
+  resetAxiosMocks();
+});
+
+test('VantaApiClient getRemediations calls paginate with correct endpoint', async () => {
+  let capturedConfig = null;
+  const mockAxiosInstance = {
+    request: async (config) => {
+      capturedConfig = config;
+      return {
+        data: {
+          results: {
+            data: [{ id: 1 }],
+            pageInfo: { hasNextPage: false },
+          },
+        },
+      };
+    },
+    defaults: {
+      headers: { common: {} },
+    },
+  };
+
+  axios.create = () => mockAxiosInstance;
+  axios.post = async () => ({
+    data: { access_token: 'test-token', expires_in: 3600 },
+  });
+
+  const apiClient = new VantaApiClient({
+    clientId: 'test-id',
+    clientSecret: 'test-secret',
+  });
+
+  await apiClient.getRemediations();
+
+  assert.equal(capturedConfig.url, '/vulnerability-remediations');
+
+  resetAxiosMocks();
+});


### PR DESCRIPTION
## Summary
- Add detailed logging of 500 error responses for API behavior diagnosis
- DO NOT automatically treat 500 errors as success to prevent masking real failures
- Add comprehensive test coverage for API client pagination and error handling

## Problem
When syncing from the Vanta API, requests to `/vulnerability-remediations` would fail with repeated 500 errors. The error log shows the sync failing after retrying with progressively smaller page sizes (100 → 50 → 25 → 12 → 6 → 3 → 1), with all requests returning 500 errors.

## Initial Approach & Feedback
The initial implementation automatically treated 500 errors with `hasNextPage: false` as successful end-of-pagination. However, this approach was **too aggressive** and could:
- Mask legitimate server errors (rate limits, auth issues, outages)
- Silently corrupt sync data by returning incomplete results
- Make it impossible for upstream code to detect and retry failures

## Conservative Solution
After feedback, the implementation was revised to:
1. **Log 500 error response bodies** for debugging without altering control flow  
2. **Always surface errors** - never mask failures by treating them as success
3. **Add comprehensive tests** to ensure error handling works correctly

## What The Code Does
When a 500 error occurs:
- Logs the complete error response body (JSON.stringify) for diagnosis
- Still throws the error so it can be properly handled upstream
- Does NOT treat any 500 as "end of pagination"
- Maintains existing retry and page-size-reduction logic

## Test Coverage
Added 7 new API client tests covering:
- Page size reduction on 500 errors
- Multi-page pagination
- Batch callback invocation
- 500 error response logging
- Ensuring legitimate errors are not masked
- Endpoint routing for vulnerabilities and remediations

All tests use setTimeout mocking to avoid slow exponential backoff delays.

## Next Steps
Run the sync operation to:
1. See the detailed error response logs
2. Determine if this is end-of-pagination or a real API issue
3. Contact Vanta support with the error details if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)